### PR TITLE
minor clarification on type Message

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -20,6 +20,8 @@ var ErrRead = errors.New("short read - malformed packet?")
 
 // A Message is the top level construct representing an IPFIX message. A well
 // formed message contains one or more sets of data or template information.
+// The array "DataRecords" stores the actual IPFIX data while "TemplateRecords"
+// stores the corresponding template at the same index.
 type Message struct {
 	Header          MessageHeader
 	DataRecords     []DataRecord


### PR DESCRIPTION
Hi calmh,

i added a minor clarification to the documentation of the type Message. The interplay between its two arrays was not clear until I read the source code. I hope my contributions are correct and save others the same trouble.

Cheers,
tpltnt
