### PR TITLE
Added support for parsing concatenated messages

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -350,3 +350,26 @@ func TestParsingTemplateAndDataRecords(t *testing.T) {
 		t.Error("Incorrect number of data records", len(msg.DataRecords))
 	}
 }
+
+func TestParsingBufferAll(t *testing.T) {
+	packet, _ := hex.DecodeString("000a00405685b3700000000000bc614e000200140100000300080004000c0004000200040100001cc0a800c9c0a80001000000ebc0a800cac0a800010000002a000a00405685b3700000000000bc614e000200140100000300080004000c0004000200040100001cc0a800c9c0a80001000000ebc0a800cac0a800010000002a000a00405685b3700000000000bc614e000200140100000300080004000c0004000200040100001cc0a800c9c0a80001000000ebc0a800cac0a800010000002a000a00405685b3700000000000bc614e000200140100000300080004000c0004000200040100001cc0a800c9c0a80001000000ebc0a800cac0a800010000002a")
+	p := ipfix.NewSession()
+
+	msgs, err := p.ParseBufferAll(packet)
+	if err != nil {
+		t.Fatal("ParseBuffer failed", err)
+	}
+
+	if len(msgs) != 4 {
+		t.Error("Incorrent number of messages", len(msgs))
+	}
+
+	for _, msg := range msgs {
+		if len(msg.TemplateRecords) != 1 {
+			t.Error("Incorrect number of template records", len(msg.TemplateRecords))
+		}
+		if len(msg.DataRecords) != 2 {
+			t.Error("Incorrect number of data records", len(msg.DataRecords))
+		}
+	}
+}


### PR DESCRIPTION
It is often then case that multiple IPFIX messages are concatenated
together into the payload of a single packet. Added a new function
which can be used to parse buffers containing multiple messages.