### PR TITLE
Add basicList support

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"math/bits"
 	"net"
 	"os"
 	"time"
@@ -169,11 +170,19 @@ func (i *Interpreter) InterpretInto(rec DataRecord, fieldList []InterpretedField
 				fieldID := uint16(number((*bs)[1:3]))
 				fieldLen := uint16(number((*bs)[3:5]))
 
+				var pen uint32 = 0
+				offset := 5
+				// Test for PEN field type
+				if bits.LeadingZeros16(fieldID) == 0 {
+					pen = uint32(number((*bs)[5:9]))
+					offset += 4
+				}
+
 				var list []interface{}
 
-				for offset := 5; offset < len(*bs); offset += int(fieldLen) {
+				for ; offset < len(*bs); offset += int(fieldLen) {
 					temp := (*bs)[offset : offset+int(fieldLen)]
-					list = append(list, interpretBytes(&temp, i.dictionary[dictionaryKey{0, fieldID}].Type))
+					list = append(list, interpretBytes(&temp, i.dictionary[dictionaryKey{pen, fieldID}].Type))
 				}
 
 				fieldList[j].Value = list

--- a/interpreter.go
+++ b/interpreter.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"net"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -167,18 +166,17 @@ func (i *Interpreter) InterpretInto(rec DataRecord, fieldList []InterpretedField
 
 			if entry.Type == BasicList {
 				bs := &rec.Fields[j]
-				semantic := uint8(number((*bs)[0:1]))
 				fieldID := uint16(number((*bs)[1:3]))
 				fieldLen := uint16(number((*bs)[3:5]))
 
-				listString := fmt.Sprintf("(semantic=%d,fieldID=%d,fieldLen=%d)[", semantic, fieldID, fieldLen)
+				var list []interface{}
 
 				for offset := 5; offset < len(*bs); offset += int(fieldLen) {
 					temp := (*bs)[offset : offset+int(fieldLen)]
-					listString = fmt.Sprintf("%s%v,", listString, interpretBytes(&temp, i.dictionary[dictionaryKey{0, fieldID}].Type))
+					list = append(list, interpretBytes(&temp, i.dictionary[dictionaryKey{0, fieldID}].Type))
 				}
 
-				fieldList[j].Value = strings.TrimRight(listString, ",") + "]"
+				fieldList[j].Value = list
 			} else {
 				fieldList[j].Value = interpretBytes(&rec.Fields[j], entry.Type)
 			}


### PR DESCRIPTION
Add support for basicList.

Results can be displayed using `ipfixcat`. Example:
```
{"name":"basicList","field":291,"value":"(semantic=4,fieldID=190,fieldLen=2)[60,52,367,52]"}
```

See RFC 6313 for more info on basicList.