### PR TITLE
Load export templates

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -555,7 +555,7 @@ func (s *Session) readVariableLength(sl *slice) (val []byte, err error) {
 }
 
 func (s *Session) ExportTemplateRecords() []TemplateRecord {
-	trs := make([]TemplateRecord, 0, len(s.specifiers))
+	trecs := make([]TemplateRecord, 0, len(s.specifiers))
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
@@ -566,7 +566,7 @@ func (s *Session) ExportTemplateRecords() []TemplateRecord {
 				FieldSpecifiers: s.specifiers[a],
 			}
 
-			trs = append(trs, tr)
+			trecs = append(trecs, tr)
 		}
 	} else {
 		for t, fs := range s.specifiers {
@@ -574,15 +574,15 @@ func (s *Session) ExportTemplateRecords() []TemplateRecord {
 				TemplateID:      t,
 				FieldSpecifiers: fs,
 			}
-			trs = append(trs, tr)
+			trecs = append(trecs, tr)
 		}
 	}
 
-	return trs
+	return trecs
 }
 
-func (s *Session) LoadTemplateRecords(trs []TemplateRecord) {
-	for _, tr := range trs {
+func (s *Session) LoadTemplateRecords(trecs []TemplateRecord) {
+	for _, tr := range trecs {
 		s.registerTemplateRecord(&tr)
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -553,3 +553,36 @@ func (s *Session) readVariableLength(sl *slice) (val []byte, err error) {
 
 	return sl.Cut(l), sl.Error()
 }
+
+func (s *Session) ExportTemplateRecords() []TemplateRecord {
+	trs := make([]TemplateRecord, 0, len(s.specifiers))
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	if s.withIDAliasing {
+		for t, a := range s.aliases {
+			tr := TemplateRecord{
+				TemplateID: t,
+				FieldSpecifiers: s.specifiers[a],
+			}
+
+			trs = append(trs, tr)
+		}
+	} else {
+		for t, fs := range s.specifiers {
+			tr := TemplateRecord{
+				TemplateID:      t,
+				FieldSpecifiers: fs,
+			}
+			trs = append(trs, tr)
+		}
+	}
+
+	return trs
+}
+
+func (s *Session) LoadTemplateRecords(trs []TemplateRecord) {
+	for _, tr := range trs {
+		s.registerTemplateRecord(&tr)
+	}
+}

--- a/parser.go
+++ b/parser.go
@@ -562,7 +562,7 @@ func (s *Session) ExportTemplateRecords() []TemplateRecord {
 	if s.withIDAliasing {
 		for t, a := range s.aliases {
 			tr := TemplateRecord{
-				TemplateID: t,
+				TemplateID:      t,
 				FieldSpecifiers: s.specifiers[a],
 			}
 


### PR DESCRIPTION
Can be used with marshal/unmarshal to implement template caching

Example code:

```go
s := ipfix.NewSession()

fmt.Println("Loading template cache")
trecsJson, _ := ioutil.ReadFile("templates.json")
trecs := make([]ipfix.TemplateRecord, 0)
json.Unmarshal(trecsJson, &trecs)
s.LoadTemplateRecords(trecs)

go func() {
	tik := time.Tick(10 * time.Second)

	for range tik {
		fmt.Println("Exporting template cache")
		trecs := s.ExportTemplateRecords()
		trecsJson, _ := json.Marshal(trecs)
		ioutil.WriteFile("templates.json", trecsJson, 0644)
	}
}()
```